### PR TITLE
feat: extended response from lambda

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { config as loadEnv } from 'dotenv';
 import { cleanEnv, str, url, CleanEnv } from 'envalid';
 import { Url } from 'url';
+import { ResponseType } from './types/common';
 
 const dotEnvPath = process.env.NODE_ENV === 'test' ? '.test.env' : '.env';
 
@@ -14,9 +15,9 @@ export const config = cleanEnv(
     REGION: str(),
     LOOKUP_API_URL: url(),
     CONSTRAINT_API_URL: url(),
-    CONSTRAINT_ID: str({ default: null }),
-    SESSION_KEY: str({ default: null }),
-    RESPONSE_TYPE: str({ default: 'BASIC' }),
+    CONSTRAINT_ID: str(),
+    SESSION_KEY: str(),
+    RESPONSE_TYPE: str({ default: ResponseType.Basic }),
   },
   {
     dotEnvPath: null,
@@ -31,6 +32,6 @@ export type AppConfig = Readonly<{
   CONSTRAINT_API_URL: Url;
   CONSTRAINT_ID: string;
   SESSION_KEY: string;
-  RESPONSE_TYPE: string;
+  RESPONSE_TYPE: ResponseType;
 }> &
   CleanEnv;

--- a/src/functions/validator.ts
+++ b/src/functions/validator.ts
@@ -10,8 +10,9 @@ import { Status } from '../utils/status';
 import { StatusCodes } from 'http-status-codes';
 import { translateErrorMessages } from '../utils/error-message-translator';
 import { config } from '../config';
+import { ResponseType } from '../types/common';
 
-export const validate = async (event: APIGatewayEvent): Promise<LambdaResponse> => {
+export const validate = async (event: APIGatewayEvent): Promise<LambdaResponse | ConstraintResponse> => {
   const queryStringParams = event.queryStringParameters || {};
   let lookupResponse: LookupLargeResponse | LambdaResponses;
   let constraintResponse: ConstraintResponse;
@@ -77,6 +78,16 @@ export const validate = async (event: APIGatewayEvent): Promise<LambdaResponse> 
 
   if (constraintResponse.returnStatus.data.length === 0) {
     return LambdaResponses.wrongConfiguration;
+  }
+
+  if (config.RESPONSE_TYPE === ResponseType.Full.toString()) {
+    return {
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+      },
+      statusCode: StatusCodes.OK,
+      body: JSON.stringify(constraintResponse),
+    };
   }
 
   [response] = constraintResponse.returnStatus.data;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -38,6 +38,11 @@ export enum StatusCodes {
   NotImplemented = 'not_implemented',
 }
 
+export enum ResponseType {
+  Basic = 'BASIC',
+  Full = 'FULL',
+}
+
 export interface Location {
   timestamp: number | string;
   version: string | number;


### PR DESCRIPTION
User can set in the config how long response should be. Lambda provides two types - basic, which contains only specific information and full - which contains the whole response from Constraint API. 